### PR TITLE
fix: pin Pytorch version to 1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each kernel is less than 200 lines of code, and is **easy to understand** and mo
 Please install it first.
 
 ```shell
-pip install torch -U --extra-index-url https://download.pytorch.org/whl/cu116
+pip install torch==1.12.1 -U --extra-index-url https://download.pytorch.org/whl/cu116
 git clone https://github.com/ELS-RD/kernl
 pip install -e .
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 triton==2.0.0.dev20221001
-torch>=1.12.0
+torch==1.12.*
 numpy
 pytest
 tabulate


### PR DESCRIPTION
new version of Pytorch (1.13.0) is not supported. Before adding support, fix crash.