### PR TITLE
feat: add google analytics (ga4) and cookie consent.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ extra:
       link: https://github.com/ELS-RD/kernl
       name: Kernl on Github
   generator: false
+  analytics:
+    provider: google
+    property: G-QC1WFMZK6C
 
 # Extensions
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,8 @@ repo_url: https://github.com/ELS-RD/kernl
 edit_uri: ""
 
 # Copyright
-copyright: Copyright &copy; 2022-2023 Lefebvre Sarrut
+copyright: Copyright &copy; 2022-2023 Lefebvre Sarrut –
+  <a href="#__consent">Change cookie settings</a>
 
 # Configuration
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,10 +80,21 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/ELS-RD/kernl
       name: Kernl on Github
-  generator: false
+  generator: false              # Disable the "Made with Material for MkDocs" footer
   analytics:
     provider: google
     property: G-QC1WFMZK6C
+  consent:
+    title: Cookie consent on kernl.ai
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
+    actions:
+      - accept
+      - reject
+      - manage
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
This PR adds GA4 and consent to cookies.

To log into the Google Analytics account, the credentials of the `open.kernl.ai@gmail.com` account are stored in bitwarden.
To run the site locally, you must refer to `/docs/README.md`.

`warn`: In order to comply with GDPR, users must be able to change their cookie settings at any time. For this, a link "Change cookie settings" has been added in the footer (see video #167). 

> Note that the cookie manager proposes to activate or not a github cookie. This material is needed to get the information from github for the link on the top right : https://github.com/squidfunk/mkdocs-material/discussions/4666

### Tests performed tests performed on Chrome, FFX desktop and Safari iOS.

- creation of `ga` cookies, or not, depending on consent: `OK`.
- send data to `ga4`: `OK`.
- reception in `ga4` (acquisition, page views, geoloc, search terms, etc.): `OK`.

Note: Tracking is more and more complicated to test as our devices are now equipped with anti-trackers (e.g. on my iPhone, even in non-private browsing, a lot of information is no longer transmitted, or are false).

fix #167 