### PR TITLE
docs: add some code reference

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocstrings
       - run: mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/docs/Dockerfile.mkdocstrings
+++ b/docs/Dockerfile.mkdocstrings
@@ -1,0 +1,4 @@
+FROM squidfunk/mkdocs-material
+
+RUN pip install --no-cache-dir \
+  pip install mkdocstrings[python]

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,14 @@
 The easiest and least intrusive way is to use docker.
 
 ```shell
+# Building a mkdocs image with the mkdocstrings plugin
+docker build -t mkdocstrings -f docs/Dockerfile.mkdocstrings docs
+
 # Previewing the site in watch mode
-docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs mkdocstrings
 
 # Build the static site
-docker run --rm -it -v ${PWD}:/docs squidfunk/mkdocs-material build
+docker run --rm -it -v ${PWD}:/docs mkdocstrings build
 ```
 
 ## Notes for developers

--- a/docs/reference/debugger.md
+++ b/docs/reference/debugger.md
@@ -1,0 +1,5 @@
+# Debugger
+
+::: src.kernl.utils.debugger
+    options:
+      show_source: false

--- a/docs/reference/extended_matcher.md
+++ b/docs/reference/extended_matcher.md
@@ -1,0 +1,5 @@
+# Graph Pattern Matching
+
+::: src.kernl.utils.extended_matcher
+    options:
+      show_source: false

--- a/docs/reference/model_optimization.md
+++ b/docs/reference/model_optimization.md
@@ -1,0 +1,5 @@
+# Model Optimization
+
+::: src.kernl.model_optimization
+    options:
+      show_source: true

--- a/docs/reference/page.md
+++ b/docs/reference/page.md
@@ -1,3 +1,0 @@
-# Welcome to kernl.ai
-
-The documentation is currently being drafted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,17 @@ markdown_extensions:
 #      user: squidfunk
 #      repo: mkdocs-material
 
+plugins:
+  - mkdocstrings:
+      custom_templates: templates
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: false
+watch:
+  - src/kernl
+
 # Page tree
 nav:
   - Home: index.md
@@ -149,7 +160,9 @@ nav:
   - How it works:
       - Page 1: how-it-works/page.md
   - Code Reference:
-      - Page 1: reference/page.md
+      - Model Optimization: reference/model_optimization.md
+      - Debugger: reference/debugger.md
+      - Graph Pattern Matching: reference/extended_matcher.md
   - Contribution guide:
       - Page 1: contribution-guide/page.md
   - Changelog & FAQ:

--- a/src/kernl/model_optimization.py
+++ b/src/kernl/model_optimization.py
@@ -34,20 +34,26 @@ def _compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
 
 
 def optimize_model(original_model: PreTrainedModel) -> None:
-    """
-    Optimizes a given model by replacing forward method by a call to optimized code.
+    """Optimizes a given model by replacing forward method by a call to optimized code.
     It is done in two steps:
+
     *  first step is to convert the given model to fx graph.
     *  second step is to replace patterns found in the graph by fast to run kernels.
 
-    Example:
-    model = AutoModel.from_pretrained(...).eval().cuda()
+    Examples:
 
-    optimize_model(model)
-    inputs = ...
-    model(**inputs)
+        ``` { .py }
+        import tensorflow as tf
 
-    @param original_model: model to optimize
+        model = AutoModel.from_pretrained(...).eval().cuda()
+
+        optimize_model(model)
+        inputs = ...
+        model(**inputs)
+        ```
+
+    Args:
+        original_model: model to optimize
     """
     assert torch.cuda.is_available(), "CUDA capacity is required to use Kernl"
     major, _ = torch.cuda.get_device_capability()

--- a/src/kernl/utils/debugger.py
+++ b/src/kernl/utils/debugger.py
@@ -32,7 +32,8 @@ class TritonDebugger:
 
         Args:
             grid: execution grid, should match what you would provide to Cuda
-            shuffle: suffle execution order like in parallel execution. Helps to avoid mistakes like relying on some order which is not possible in parallel execution.
+            shuffle: suffle execution order like in parallel execution. Helps to avoid mistakes like relying
+                on some order which is not possible in parallel execution.
         """
         self.grid_positions = list(product(*(range(axis) for axis in grid)))
         if shuffle:

--- a/src/kernl/utils/debugger.py
+++ b/src/kernl/utils/debugger.py
@@ -28,11 +28,11 @@ class TritonDebugger:
     float16 = torch.float16
 
     def __init__(self, grid: list[int], shuffle: bool = False):
-        """
-        Initialize a serialized triton code runner.
-        :param grid: execution grid, should match what you would provide to Cuda
-        :param shuffle: suffle execution order like in parallel execution. Helps to avoid mistakes like relying on
-            some order which is not possible in parallel execution.
+        """Initialize a serialized triton code runner.
+
+        Args:
+            grid: execution grid, should match what you would provide to Cuda
+            shuffle: suffle execution order like in parallel execution. Helps to avoid mistakes like relying on some order which is not possible in parallel execution.
         """
         self.grid_positions = list(product(*(range(axis) for axis in grid)))
         if shuffle:
@@ -48,9 +48,10 @@ class TritonDebugger:
         self.total_gm_write = 0
 
     def _add_input_if_not_exists(self, tensor: torch.Tensor):
-        """
-        Add inputs for triton debugger.
-        @param tensor: torch.Tensor to be added as input
+        """Add inputs for triton debugger.
+
+        Args:
+            tensor: torch.Tensor to be added as input
         """
         if any([x is tensor for x in self.tensor_dict.values()]):
             return
@@ -61,34 +62,40 @@ class TritonDebugger:
         self.range_tensor_dict = RangeKeyDict(self.tensor_dict)
 
     def new_program(self):
-        """
-        Update program id from the grid.
-        """
+        """Update program id from the grid."""
         self.current_grid_position = self.grid_positions.pop(0)
 
     def program_id(self, axis: int) -> torch.Tensor:
-        """
-        Get program id for the given axis.
-        :param axis: axis to get program id for. Should be 0, 1, 2.
-        :return: program ID as a tensor
+        """Get program id for the given axis.
+
+        Args:
+            axis: axis to get program id for. Should be 0, 1, 2.
+
+        Returns:
+            program ID as a tensor
         """
         assert axis in [0, 1, 2]
         return torch.tensor(self.current_grid_position[axis])
 
     def has_next(self) -> bool:
-        """
-        Check if there is another program to run.
-        :return: True if there is another program to run, False otherwise.
+        """Check if there is another program to run.
+
+        Returns:
+            True if there is another program to run, False otherwise.
         """
         return len(self.grid_positions) > 0
 
     @staticmethod
     def offset_to_indexes(tensor: torch.Tensor, offsets: torch.Tensor) -> list[torch.Tensor]:
-        """
-        Convert the offsets to indexes of a given tensor using each axis stride.
-        :param tensor: tensor to get indexes for.
-        :param offsets: offsets to convert to indexes.
-        :return: list of indexes for each axis.
+        """Convert the offsets to indexes of a given tensor using each axis stride.
+
+        Args:
+            tensor: tensor to get indexes for.
+            offsets: offsets to convert to indexes.
+
+        Returns:
+
+            list of indexes for each axis.
         """
         coordinates: list[torch.Tensor] = list()
         for dim in range(0, tensor.ndim):
@@ -100,22 +107,25 @@ class TritonDebugger:
         return coordinates
 
     def _get_tensor(self, ptr: torch.Tensor) -> torch.Tensor:
-        """
-        Get tensor from the input dictionary.
-        :param ptr: pointer to the tensor.
-        :return:
+        """Get tensor from the input dictionary.
+
+        Args:
+            ptr: pointer to the tensor.
         """
         first_elem_ptr = ptr.flatten()[0].item()
         tensor = self.range_tensor_dict[first_elem_ptr]
         return tensor
 
     def _get_indexes(self, tensor: torch.Tensor, ptr: torch.Tensor, mask: torch.Tensor) -> list[Tensor]:
-        """
-        Convert the pointers to indexes of a given tensor.
-        :param tensor: tensor to get indexes for.
-        :param ptr: pointer to the tensor.
-        :param mask: mask to apply to the pointers.
-        :return: list of indexes.
+        """Convert the pointers to indexes of a given tensor.
+
+        Args:
+            tensor: tensor to get indexes for.
+            ptr: pointer to the tensor.
+            mask: mask to apply to the pointers.
+
+        Returns:
+            list of indexes.
         """
         first_ptr = self.tensor_ptr[tensor]
         offsets = ptr - first_ptr
@@ -126,13 +136,16 @@ class TritonDebugger:
     def load(
         self, ptr: torch.Tensor, mask: Optional[torch.Tensor] = None, other: float = 0.0, eviction_policy: str = ""
     ) -> torch.Tensor:
-        """
-        Load data from the provided pointers / mask.
-        :param ptr: pointers to the data.
-        :param mask: mask to apply to the pointers.
-        :param other: value to return if the position is masked.
-        :param eviction_policy: not used, just for compatibility
-        :return: loaded data.
+        """Load data from the provided pointers / mask.
+
+        Args:
+            ptr: pointers to the data.
+            mask: mask to apply to the pointers.
+            other: value to return if the position is masked.
+            eviction_policy: not used, just for compatibility
+
+        Returns:
+            loaded data.
         """
         if mask is None:
             mask = torch.ones_like(ptr).bool()
@@ -144,11 +157,12 @@ class TritonDebugger:
         return block
 
     def store(self, ptr: torch.Tensor, data: torch.Tensor, mask: Optional[torch.Tensor] = None) -> None:
-        """
-        Store tensor to the provided pointers / mask.
-        :param ptr: pointers where to store the provided data.
-        :param data: data to store.
-        :param mask: mask to apply to the pointers/data.
+        """Store tensor to the provided pointers / mask.
+
+        Args:
+            ptr: pointers where to store the provided data.
+            data: data to store.
+            mask: mask to apply to the pointers/data.
         """
         if mask is None:
             mask = torch.ones_like(ptr).bool()
@@ -158,21 +172,27 @@ class TritonDebugger:
         self.total_gm_write += mask.sum().item()
 
     def get_ptr(self, tensor: torch.Tensor) -> int:
-        """
-        Get pointer to the beginning of the given tensor.
-        :param tensor: input tensor
-        :return: pointer as an integer
+        """Get pointer to the beginning of the given tensor.
+
+        Args:
+            tensor: input tensor
+
+        Returns:
+            pointer as an integer
         """
         self._add_input_if_not_exists(tensor)
         return self.tensor_ptr[tensor]
 
     @staticmethod
     def arange(start: int, end: int) -> torch.Tensor:
-        """
-        Returns contiguous values within the open interval [start, end).
-        @param start: start of the interval
-        @param end: end of the interval. Must be a power of two >= start.
-        @return: a tensor of size (end - start) with values in [start, end).
+        """Returns contiguous values within the open interval [start, end).
+
+        Args:
+            start: start of the interval
+            end: end of the interval. Must be a power of two >= start.
+
+        Returns:
+            a tensor of size (end - start) with values in [start, end).
         """
         assert (end & (end - 1) == 0) and end != 0, f"end must be a power of 2: {end}"
         assert start < end, f"start must be less than end: {start} > {end}"
@@ -180,9 +200,7 @@ class TritonDebugger:
 
     @staticmethod
     def cdiv(x: int, y: int) -> int:
-        """
-        Ceiling division returns the closest integer greater than or equal to the quotient.
-        """
+        """Ceiling division returns the closest integer greater than or equal to the quotient."""
         return (x + y - 1) // y
 
     @staticmethod
@@ -221,12 +239,12 @@ class TritonDebugger:
 
     @staticmethod
     def rand(seed: int, offset: torch.Tensor, n_rounds: int = 10):
-        """
-        Generate random data. Seed is not used as it would produce always the same pattern.
-        :param seed: not used
-        :param offset: random tensor will have offset shape.
-        :param n_rounds: not used
-        :return:
+        """Generate random data. Seed is not used as it would produce always the same pattern.
+
+        Args:
+            seed: not used
+            offset: random tensor will have offset shape.
+            n_rounds: not used
         """
         # seed not used as it would produce always the same pattern
         return torch.rand(offset.shape, device="cuda")
@@ -237,11 +255,14 @@ class TritonDebugger:
 
     @staticmethod
     def multiple_of(input: int, values: int) -> int:
-        """
-        Used to type the compiler, we just return input argument.
-        :param input: some input
-        :param values: input guaranted multiple of.
-        :return: input argument.
+        """Used to type the compiler, we just return input argument.
+
+        Args:
+            input: some input
+            values: input guaranted multiple of.
+
+        Returns:
+            input argument.
         """
         return input
 

--- a/src/kernl/utils/extended_matcher.py
+++ b/src/kernl/utils/extended_matcher.py
@@ -203,24 +203,30 @@ class SubgraphMatcher:
         """
         Returns:
             The matched subgraphs.
-            Thre returned subgraph would be fully self-contained, meaning the nodes (except placeholder
-            and nodes returned by output) can only be consumed by nodes within the matched subgraph.
+                Thre returned subgraph would be fully self-contained, meaning the nodes (except placeholder
+                and nodes returned by output) can only be consumed by nodes within the matched subgraph.
+
         Subgraph pattern matcher is implemented with the backtracking style in the following steps:
+
         1. We first identify all the anchor nodes in the pattern graph. The anchor nodes
         are the "sinks" (nodes with no user other than the output node) of the pattern graph.
         One pattern graph could have multiple anchors if it has multiple return values.
+
         2. In the target graph, we identify the potential candidate nodes that can be matched
         with each anchor. These anchor-candidate pairs are the starting points for
         pairwise per-node matching.
+
         3. For each anchor-candidate pair, we simultaneously traverse backwards (DFS) in both
         pattern and target graphs. For every pattern nodes along traversal path, we compare it
         against the target nodes. In case any comparison failed, the match for this anchor-candidate
         pair fails. A match is found when DFS completes traversing the graph. See `self._match_nodes`
         for more details.
+
         4. In the case of multiple anchors, every anchor will need to find a match using step 3.
         In addition, the matches found between anchors need to have a common intersection node
         in order for the match to be valid. This is implemented with backtracking. See `backtracking`
         for more details.
+
         Notice: graph traversal must be done in the reverser order because a tensor can have multiple
         consumers, but can only have a single producer. Only with reverser order, we can we jointly
         traverse the pattern and target graph in a deterministic path.
@@ -335,42 +341,46 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
 
 
 def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -> List[Match]:
-    """
-    Matches all possible non-overlapping sets of operators and their
+    """Matches all possible non-overlapping sets of operators and their
     data dependencies (``pattern``) in the Graph of a GraphModule
     (``gm``), then replaces each of these matched subgraphs with another
     subgraph (``replacement``).
+
     Args:
-        ``gm``: The GraphModule that wraps the Graph to operate on
-        ``pattern``: The subgraph to match in ``gm`` for replacement
-        ``replacement``: The subgraph to replace ``pattern`` with
+        gm: The GraphModule that wraps the Graph to operate on
+        pattern: The subgraph to match in ``gm`` for replacement
+        replacement: The subgraph to replace ``pattern`` with
+
     Returns:
         List[Match]: A list of ``Match`` objects representing the places
-        in the original graph that ``pattern`` was matched to. The list
-        is empty if there are no matches. ``Match`` is defined as:
-        .. code-block:: python
+            in the original graph that ``pattern`` was matched to. The list
+            is empty if there are no matches. ``Match`` is defined as:
+            ``` { .py }
             class Match(NamedTuple):
                 # Node from which the match was found
                 anchor: Node
                 # Maps nodes in the pattern subgraph to nodes in the larger graph
                 nodes_map: Dict[Node, Node]
+            ```
+
     Examples:
-    .. code-block:: python
-        import torch
-        from torch.fx import symbolic_trace, subgraph_rewriter
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-            def forward(self, x, w1, w2):
-                m1 = torch.cat([w1, w2]).sum()
-                m2 = torch.cat([w1, w2]).sum()
-                return x + torch.max(m1) + torch.max(m2)
-        def pattern(w1, w2):
-            return torch.cat([w1, w2]).sum()
-        def replacement(w1, w2):
-            return torch.stack([w1, w2])
-        traced_module = symbolic_trace(M())
-        subgraph_rewriter.replace_pattern(traced_module, pattern, replacement)
+    ``` { .py }
+    import torch
+    from torch.fx import symbolic_trace, subgraph_rewriter
+    class M(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+        def forward(self, x, w1, w2):
+            m1 = torch.cat([w1, w2]).sum()
+            m2 = torch.cat([w1, w2]).sum()
+            return x + torch.max(m1) + torch.max(m2)
+    def pattern(w1, w2):
+        return torch.cat([w1, w2]).sum()
+    def replacement(w1, w2):
+        return torch.stack([w1, w2])
+    traced_module = symbolic_trace(M())
+    subgraph_rewriter.replace_pattern(traced_module, pattern, replacement)
+    ```
     The above code will first match ``pattern`` in the ``forward``
     method of ``traced_module``. Pattern-matching is done based on
     use-def relationships, not node names. For example, if you had
@@ -381,6 +391,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     value only; it may or may not match to the ``return`` statement in
     the larger graph. In other words, the pattern doesn't have to extend
     to the end of the larger graph.
+
     When the pattern is matched, it will be removed from the larger
     function and replaced by ``replacement``. If there are multiple
     matches for ``pattern`` in the larger function, each non-overlapping
@@ -390,6 +401,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     of the Nodes' use-def relationships. In most cases, the first Node
     is the parameter that appears directly after ``self``, while the
     last Node is whatever the function returns.)
+
     One important thing to note is that the parameters of the
     ``pattern`` Callable must be used in the Callable itself,
     and the parameters of the ``replacement`` Callable must match
@@ -398,29 +410,32 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     ``pattern`` function only has parameters ``w1, w2``. ``pattern``
     doesn't use ``x``, so it shouldn't specify ``x`` as a parameter.
     As an example of the second rule, consider replacing
-    .. code-block:: python
-        def pattern(x, y):
-            return torch.neg(x) + torch.relu(y)
+    ``` { .py }
+    def pattern(x, y):
+        return torch.neg(x) + torch.relu(y)
+    ```
     with
-    .. code-block:: python
-        def replacement(x, y):
-            return torch.relu(x)
+    ``` { .py }
+    def replacement(x, y):
+        return torch.relu(x)
+    ```
     In this case, ``replacement`` needs the same number of parameters
     as ``pattern`` (both ``x`` and ``y``), even though the parameter
     ``y`` isn't used in ``replacement``.
     After calling ``subgraph_rewriter.replace_pattern``, the generated
     Python code looks like this:
-    .. code-block:: python
-        def forward(self, x, w1, w2):
-            stack_1 = torch.stack([w1, w2])
-            sum_1 = stack_1.sum()
-            stack_2 = torch.stack([w1, w2])
-            sum_2 = stack_2.sum()
-            max_1 = torch.max(sum_1)
-            add_1 = x + max_1
-            max_2 = torch.max(sum_2)
-            add_2 = add_1 + max_2
-            return add_2
+    ``` { .py }
+    def forward(self, x, w1, w2):
+        stack_1 = torch.stack([w1, w2])
+        sum_1 = stack_1.sum()
+        stack_2 = torch.stack([w1, w2])
+        sum_2 = stack_2.sum()
+        max_1 = torch.max(sum_1)
+        add_1 = x + max_1
+        max_2 = torch.max(sum_2)
+        add_2 = add_1 + max_2
+        return add_2
+    ```
     """
 
     # Get the graphs for `gm`, `pattern`, `replacement`

--- a/src/kernl/utils/extended_matcher.py
+++ b/src/kernl/utils/extended_matcher.py
@@ -227,11 +227,12 @@ class SubgraphMatcher:
         in order for the match to be valid. This is implemented with backtracking. See `backtracking`
         for more details.
 
-        Notice: graph traversal must be done in the reverser order because a tensor can have multiple
-        consumers, but can only have a single producer. Only with reverser order, we can we jointly
-        traverse the pattern and target graph in a deterministic path.
-        Warning: In theory, this backtracking algorithm have an **exponential** time complexity. However,
-        in practice, it's unlikely to blow up.
+        Note:
+            graph traversal must be done in the reverser order because a tensor can have multiple
+            consumers, but can only have a single producer. Only with reverser order, we can we jointly
+            traverse the pattern and target graph in a deterministic path.
+            Warning: In theory, this backtracking algorithm have an **exponential** time complexity. However,
+            in practice, it's unlikely to blow up.
         """
 
         # find candidate nodes to match with pattern anchors


### PR DESCRIPTION
Add code reference in website documentation. closes #202 

This uses [mkdocstrings](https://mkdocstrings.github.io/).
Code must follow [google python docstrings format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) . It should use mkdocs-material features to highlight code by writing
````
``` { .py }
python_code
```
````

We may be able to add automatically add the whole package documentation but [it's a bit a hassle](https://mkdocstrings.github.io/recipes/#automatic-code-reference-pages)
