### PR TITLE
fix: site deployment workflow miss mkdocstrings python handler

### DIFF
--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocstrings
+      - run: pip install mkdocs-material "mkdocstrings[python]"
       - run: mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Some handler was missing in the deploy workflow for mkdocstrings. Fixed that.
Tested locally with act.