### PR TITLE
fix: update pytorch nightly to fix memory leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 &&
 
 RUN python3.9 -m ensurepip --default-pip --upgrade
 
-RUN pip install --pre torch==2.0.0.dev20230104+cu117 --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+RUN pip install --pre torch==2.0.0.dev20230119+cu117 --extra-index-url https://download.pytorch.org/whl/nightly/cu117
 
 
 WORKDIR /syncback

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 triton==2.0.0.dev20221202
-torch==2.0.0.dev20230104+cu117
+torch==2.0.0.dev20230119+cu117
 pytest
 tabulate
 termcolor

--- a/src/kernl/optimizer/cuda_graph.py
+++ b/src/kernl/optimizer/cuda_graph.py
@@ -17,8 +17,8 @@ from typing import Callable, Union
 
 import torch
 import triton
+from torch._dynamo import utils as dynamo_utils
 from torch._inductor.compile_fx import cudagraphify_impl
-from torch._inductor.utils import dynamo_utils
 from torch._subclasses import FakeTensor
 
 


### PR DESCRIPTION
With current version of PyTorch there is a memory leak that can be reproduced if we follow the code below:
https://github.com/pytorch/torchdynamo/issues/1955#issuecomment-1361343403

Updating PyTorch fixes the issue.

test pass
```shell
> pytest

================================================================================================== 2859 passed in 6454.06s (1:47:34) ===================================================================================================
```