### PR TITLE
feat: add support for int8 quantization on linear layers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         cache: 'pip'
     - run: pip install black flake8 isort
     - run: make source_code_check_format
-    - run: pip install -e . --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+    - run: pip install -e . --extra-index-url https://download.pytorch.org/whl/nightly/cu118
     - run: pytest --verbose
   notebooks-changes:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 &
 RUN python3.9 -m ensurepip --default-pip --upgrade && \
     pip install --upgrade pip
 
-RUN pip install --pre torch==2.0.0.dev20230128+cu117 --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+RUN pip install --pre torch==dev20230226+cu118 --extra-index-url https://download.pytorch.org/whl/nightly/cu118
 
 RUN mkdir /syncback
 WORKDIR /kernl

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ A list of Examples contains how to use kernl with Pytorch.
 Please install it first.
 
 ```shell
-pip install 'git+https://github.com/ELS-RD/kernl' --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+pip install 'git+https://github.com/ELS-RD/kernl' --extra-index-url https://download.pytorch.org/whl/nightly/cu118
 # or for local dev, after git clone ...
-pip install -e . --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+pip install -e . --extra-index-url https://download.pytorch.org/whl/nightly/cu118
 ```
 
 This project requires `Python` >= 3.9.

--- a/docs/how-to-guides/get-started.md
+++ b/docs/how-to-guides/get-started.md
@@ -5,7 +5,7 @@
 To install Kernl library, you just have to pip install it:
 
 ``` { .bash }
-python3 -m pip install install 'git+https://github.com/ELS-RD/kernl' --extra-index-url https://download.pytorch.org/whl/nightly/cu117
+python3 -m pip install install 'git+https://github.com/ELS-RD/kernl' --extra-index-url https://download.pytorch.org/whl/nightly/cu118
 ```
 
 ## Optimize a model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 triton==2.0.0.dev20221202
-torch==2.0.0.dev20230128+cu117
+torch==2.0.0.dev20230226+cu118
 pytest
 tabulate
 termcolor

--- a/src/kernl/implementations/linear_layer.py
+++ b/src/kernl/implementations/linear_layer.py
@@ -219,7 +219,7 @@ def kernel_linear(
         acc *= ALPHA_SCALER
 
     if HAS_BIAS:
-        bias = tl.load(bias + n_offs, mask=n_offs < N, other=0.0).to(ACC_TYPE)  # TODO fix when Triton updated
+        bias = tl.load(bias + n_offs, mask=n_offs < N, other=0.0)  # .to(ACC_TYPE)  # TODO fix when Triton updated
         if BETA_SCALER != 1.0:
             bias *= BETA_SCALER
         acc += bias[None, :]
@@ -266,7 +266,7 @@ class LinearLayer(torch.autograd.Function):
         :param x: input tensor
         :param weight: weight matrix
         :param bias: an optional bias tensor
-        :param activation: Activation name. Needs to be a Triton kernel.
+        :param activation: Activation name (relu, tanh, gelu, fast_gelu)
         :param act_inputs: an optional tensor to save the activation inputs (for backward)
         :param alpha_scaler: alpha scaler (to be appled on mamtul output)
         :param beta_scaler: beta scaler (to be applied on bias)

--- a/src/kernl/implementations/linear_layer_quant.py
+++ b/src/kernl/implementations/linear_layer_quant.py
@@ -1,0 +1,200 @@
+#  Copyright 2022 Lefebvre Sarrut
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# code inspired from torch-int pacakge
+# https://github.com/Guangxuan-Xiao/torch-int/blob/main/torch_int/nn/linear.py
+
+import torch
+
+from kernl.implementations.linear_layer import linear_layer
+
+
+@torch.no_grad()
+def quantize_per_tensor_absmax(t: torch.Tensor):
+    scale = t.abs().max() / 127
+    if not t.is_cuda:
+        # half rounding is not supported on CPU
+        t = t.float()
+    # use inplace operation to save memory
+    t.div_(scale).round_()
+    t_q = t.to(torch.int8)
+    return t_q, scale
+
+
+class W8A8B8O8Linear(torch.nn.Module):
+    # For qkv_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer(
+            "weight",
+            torch.randint(-127, 127, (self.out_features, self.in_features), dtype=torch.int8, requires_grad=False),
+        )
+        self.register_buffer("bias", torch.zeros((1, self.out_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer("a", torch.tensor(alpha))
+        self.register_buffer("b", torch.tensor(beta))
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        y = torch.empty((x.shape[0], self.weight.shape[0]), device=x.device, dtype=torch.int8)
+        linear_layer(
+            x=x,
+            weight=self.weight,
+            bias=self.bias,
+            activation="",
+            act_inputs=None,
+            alpha_scaler=self.a.item(),
+            beta_scaler=self.b.item(),
+            output=y,
+        )
+        y = y.view(*x_shape[:-1], -1)
+        return y
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale, output_scale):
+        int8_module = W8A8B8O8Linear(module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        int8_bias, bias_scale = quantize_per_tensor_absmax(module.bias)
+        alpha = input_scale * weight_scale / output_scale
+        beta = bias_scale / output_scale
+        int8_module.weight = int8_weight
+        int8_module.bias = int8_bias
+        int8_module.a = alpha
+        int8_module.b = beta
+        return int8_module
+
+
+class W8A8B8O8LinearReLU(torch.nn.Module):
+    # For fc1
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer(
+            "weight",
+            torch.randint(-127, 127, (self.out_features, self.in_features), dtype=torch.int8, requires_grad=False),
+        )
+        self.register_buffer("bias", torch.zeros((1, self.out_features), dtype=torch.int8, requires_grad=False))
+        self.register_buffer("a", torch.tensor(alpha))
+        self.register_buffer("b", torch.tensor(beta))
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        y = torch.empty((x.shape[0], self.weight.shape[0]), device=x.device, dtype=torch.int8)
+
+        linear_layer(
+            x=x,
+            weight=self.weight,
+            bias=self.bias,
+            activation="relu",
+            act_inputs=None,
+            alpha_scaler=self.a.item(),
+            beta_scaler=self.b.item(),
+            output=y,
+        )
+        y = y.view(*x_shape[:-1], -1)
+        return y
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale, output_scale):
+        # TODO: add zero-point to prevent the bit waste
+        int8_module = W8A8B8O8LinearReLU(module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        int8_bias, bias_scale = quantize_per_tensor_absmax(module.bias)
+        alpha = input_scale * weight_scale / output_scale
+        beta = bias_scale / output_scale
+        int8_module.weight = int8_weight
+        int8_module.bias = int8_bias
+        int8_module.a = alpha
+        int8_module.b = beta
+        return int8_module
+
+
+class W8A8BFP32OFP32Linear(torch.nn.Module):
+    # For fc2 and out_proj
+    def __init__(self, in_features, out_features, alpha=1.0, beta=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer(
+            "weight",
+            torch.randint(-127, 127, (self.out_features, self.in_features), dtype=torch.int8, requires_grad=False),
+        )
+        self.register_buffer("bias", torch.zeros((1, self.out_features), dtype=torch.float32, requires_grad=False))
+        self.register_buffer("a", torch.tensor(alpha))
+
+    def _apply(self, fn):
+        # prevent the bias from being converted to half
+        super()._apply(fn)
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.weight = self.weight.to(*args, **kwargs)
+        self.bias = self.bias.to(*args, **kwargs)
+        self.bias = self.bias.to(torch.float32)
+        return self
+
+    @torch.no_grad()
+    def forward(self, x):
+        x_shape = x.shape
+        x = x.view(-1, x_shape[-1])
+        self.bias = self.bias.to(torch.float32)
+        y = torch.empty((x.shape[0], self.weight.shape[0]), device=x.device, dtype=torch.float32)
+
+        linear_layer(
+            x=x,
+            weight=self.weight,
+            bias=self.bias,
+            activation="",
+            act_inputs=None,
+            alpha_scaler=self.a.item(),
+            beta_scaler=1.0,
+            output=y,
+        )
+        y = y.view(*x_shape[:-1], -1)
+        return y
+
+    @staticmethod
+    def from_float(module: torch.nn.Linear, input_scale):
+        int8_module = W8A8BFP32OFP32Linear(module.in_features, module.out_features)
+        int8_weight, weight_scale = quantize_per_tensor_absmax(module.weight)
+        alpha = input_scale * weight_scale
+        int8_module.weight = int8_weight
+        int8_module.bias = module.bias.to(torch.float32)
+        int8_module.a = alpha
+        int8_module.input_scale = input_scale
+        int8_module.weight_scale = weight_scale
+        return int8_module

--- a/test/test_linear_layer.py
+++ b/test/test_linear_layer.py
@@ -41,7 +41,9 @@ implementations = {
     "pytorch": lambda weight, bias, activation: lambda x: get_pytorch_activation(activation)(
         torch.nn.functional.linear(x, weight, bias)
     ),
-    "triton": lambda weight, bias, activation: lambda x: linear_layer(x, weight, bias, activation),
+    "triton": lambda weight, bias, activation: lambda x: linear_layer(
+        x=x, weight=weight, bias=bias, activation=activation
+    ),
 }
 
 

--- a/test/test_linear_layer.py
+++ b/test/test_linear_layer.py
@@ -97,3 +97,35 @@ def test_benchmark(
     value = benchmark(fn, x)
 
     assert_all_close(expected, value.float(), rtol=1e-1, atol=1e-1)
+
+
+@set_seed()
+@pytest.mark.parametrize("implementation", ["triton", "pytorch"])
+def test_quant_linear_a8_w8_b32_o32(benchmark, implementation):
+    alpha, beta = 0.01, 0.0001
+    B, M, N = 128, 512, 1024
+    min_int8 = torch.iinfo(torch.int8).min
+    max_int8 = torch.iinfo(torch.int8).max
+    min_bias = int(torch.finfo(torch.float16).min)  # because bias will be converted to fp16 for benchmark reason
+    max_bias = int(torch.finfo(torch.float16).max)
+    weight = torch.randint(min_int8, max_int8, (N, M), dtype=torch.int8, device="cuda")
+    bias = torch.randint(min_bias, max_bias, (N,), dtype=torch.int32, device="cuda")
+    x = torch.randint(min_int8, max_int8, (B, M), dtype=torch.int8, device="cuda")
+    linear = torch.nn.Linear(M, N, bias=True)
+    linear.weight.data = weight.half() * alpha
+    linear.bias.data = bias.half() * beta
+    y_pytorch = linear(x.half())
+    assert torch.all(torch.isfinite(y_pytorch))
+
+    if implementation == "triton":
+        y_triton = torch.zeros((B, N), device="cuda")
+        y_triton = linear_layer(x, weight, bias, "", None, alpha, beta, y_triton)
+        assert_all_close(y_pytorch, y_triton.half(), rtol=0, atol=4)  # not eq as baseline is computed with floats
+        fn = lambda: linear_layer(x, weight, bias, "", None, alpha, beta, y_triton)  # noqa: E731
+    elif implementation == "pytorch":
+        x = x.half()
+        fn = lambda: linear(x)  # noqa: E731
+    else:
+        raise ValueError(f"Unknown implementation: {implementation}")
+
+    benchmark(fn)

--- a/test/test_linear_layer_quant.py
+++ b/test/test_linear_layer_quant.py
@@ -1,0 +1,109 @@
+#  Copyright 2022 Lefebvre Sarrut
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+import torch
+
+from conftest import assert_all_close, set_seed
+
+from kernl.implementations.linear_layer import linear_layer
+from kernl.implementations.linear_layer_quant import W8A8B8O8Linear, W8A8B8O8LinearReLU, W8A8BFP32OFP32Linear
+
+
+@set_seed()
+@pytest.mark.parametrize("implementation", ["triton", "pytorch"])
+def test_quant_linear_a8_w8_b32_o32(benchmark, implementation):
+    alpha, beta = 0.01, 0.0001
+    B, M, N = 128, 512, 1024
+    min_int8 = torch.iinfo(torch.int8).min
+    max_int8 = torch.iinfo(torch.int8).max
+    min_bias = int(torch.finfo(torch.float16).min)  # because bias will be converted to fp16 for benchmark reason
+    max_bias = int(torch.finfo(torch.float16).max)
+    weight = torch.randint(min_int8, max_int8, (N, M), dtype=torch.int8, device="cuda")
+    bias = torch.randint(min_bias, max_bias, (N,), dtype=torch.int32, device="cuda")
+    x = torch.randint(min_int8, max_int8, (B, M), dtype=torch.int8, device="cuda")
+    linear = torch.nn.Linear(M, N, bias=True)
+    linear.weight.data = weight.half() * alpha
+    linear.bias.data = bias.half() * beta
+    y_pytorch = linear(x.half())
+    assert torch.all(torch.isfinite(y_pytorch))
+
+    if implementation == "triton":
+        y_triton = torch.zeros((B, N), device="cuda")
+        y_triton = linear_layer(x, weight, bias, "", None, alpha, beta, y_triton)
+        assert_all_close(y_pytorch, y_triton.half(), rtol=0, atol=4)  # not eq as baseline is computed with floats
+        fn = lambda: linear_layer(  # noqa: E731
+            x=x,
+            weight=weight,
+            bias=bias,
+            activation="",
+            act_inputs=None,
+            alpha_scaler=alpha,
+            beta_scaler=beta,
+            output=y_triton,
+        )
+    elif implementation == "pytorch":
+        x = x.half()
+        fn = lambda: linear(x)  # noqa: E731
+    else:
+        raise ValueError(f"Unknown implementation: {implementation}")
+
+    benchmark(fn)
+
+
+@set_seed()
+@torch.no_grad()
+def test_w8a8b8o8_linear_relu():
+    B, M, N = 128, 512, 1024
+    x = torch.randn(B, M)
+    x_scale = x.abs().max() / 127
+    qx = (x / x_scale).round().to(torch.int8)
+    linear = torch.nn.Linear(M, N, bias=True)
+    y_gt = linear(x).clamp(min=0)
+    y_scale = y_gt.abs().max() / 127
+    q_linear = W8A8B8O8LinearReLU.from_float(linear, x_scale, y_scale).cuda()
+    q_y = q_linear(qx.cuda()).cpu()
+    y_hat = q_y * y_scale
+    assert_all_close(y_gt, y_hat, rtol=0, atol=1e-1)
+
+
+@set_seed()
+@torch.no_grad()
+def test_w8a8b8o8_linear():
+    B, M, N = 128, 512, 1024
+    x = torch.randn(B, M)
+    x_scale = x.abs().max() / 127
+    qx = (x / x_scale).round().to(torch.int8)
+    linear = torch.nn.Linear(M, N, bias=True)
+    y_gt = linear(x)
+    y_scale = y_gt.abs().max() / 127
+    q_linear = W8A8B8O8Linear.from_float(linear, x_scale, y_scale).cuda()
+    q_y = q_linear(qx.cuda()).cpu()
+    y_hat = q_y * y_scale
+    assert_all_close(y_gt, y_hat, rtol=0, atol=1e-1)
+
+
+@set_seed()
+@torch.no_grad()
+def test_w8a8bfp32ofp32_linear():
+    B, M, N = 128, 512, 1024
+    x = torch.randn(B, M)
+    x_scale = x.abs().max() / 127
+    qx = (x / x_scale).round().to(torch.int8)
+    linear = torch.nn.Linear(M, N, bias=True)
+    y_gt = linear(x)
+    q_linear = W8A8BFP32OFP32Linear.from_float(linear, x_scale).cuda()
+    y_hat = q_linear(qx.cuda()).cpu()
+    assert_all_close(y_gt, y_hat, rtol=0, atol=1e-1)


### PR DESCRIPTION
- add int8 matmul + scalers support
- update PyTorch to last available (post branch cut)

test pass

```log

================================================== warnings summary ==================================================
test/test_model_optimization.py: 1 warning
test/test_torchdynamo.py: 79 warnings
  /home/geantvert/.local/share/virtualenvs/kernl/lib/python3.9/site-packages/torch/cuda/graphs.py:79: UserWarning: The CUDA Graph is empty. This ususally means that the graph was attempted to be captured on wrong device or stream. (Triggered internally at ../aten/src/ATen/cuda/CUDAGraph.cpp:191.)
    super().capture_end()

test/debugger/test_memory.py::test_load_is_in_different_memory
  /mnt/workspace/kernl/test/debugger/test_memory.py:58: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
    assert t.storage().data_ptr() != a.storage().data_ptr()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= 2885 passed, 3 skipped, 81 warnings in 10684.37s (2:58:04) =============================
```