### PR TITLE
feat: make pytest in CI non verbose

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     - run: pip install black flake8 isort
     - run: make source_code_check_format
     - run: pip install -e . --extra-index-url https://download.pytorch.org/whl/nightly/cu117
-    - run: pytest --verbose
+    - run: pytest
   notebooks-changes:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Right now PyTest is run in verbose mode in the CI.
The artefact are very hard to work with, for instance https://github.com/ELS-RD/kernl/actions/runs/4275131333
Main use case for the CI is to show where it crashes and provide basic details for repro, non verbose run should be ok.