### PR TITLE
fix: removes/comments empty sections and navigations.

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -199,7 +199,7 @@ model <span class="instruction">=</span> <span class="class">AutoModel</span>.<s
                     </p>
                 </div>
 <!--                <footer>-->
-<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary&#45;&#45;outlined">-->
+<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary--outlined">-->
 <!--                        <span>See how it works</span>-->
 <!--                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
 <!--                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>-->
@@ -243,7 +243,7 @@ model <span class="instruction">=</span> <span class="class">AutoModel</span>.<s
                     </p>
                 </div>
 <!--                <footer>-->
-<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary&#45;&#45;outlined">-->
+<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary--outlined">-->
 <!--                        <span>See more benchmarks</span>-->
 <!--                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
 <!--                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>-->

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -198,14 +198,14 @@ model <span class="instruction">=</span> <span class="class">AutoModel</span>.<s
                         <em>training</em>.
                     </p>
                 </div>
-                <footer>
-                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary--outlined">
-                        <span>See how it works</span>
-                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>
-                        </svg>
-                    </a>
-                </footer>
+<!--                <footer>-->
+<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary&#45;&#45;outlined">-->
+<!--                        <span>See how it works</span>-->
+<!--                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
+<!--                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>-->
+<!--                        </svg>-->
+<!--                    </a>-->
+<!--                </footer>-->
             </div>
         </div>
         <div class="knl-highlight md-grid slide-up">
@@ -242,14 +242,14 @@ model <span class="instruction">=</span> <span class="class">AutoModel</span>.<s
                         <em>T5 is also 6 times faster</em> (and we are still halfway through the optimizations!).
                     </p>
                 </div>
-                <footer>
-                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary--outlined">
-                        <span>See more benchmarks</span>
-                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>
-                        </svg>
-                    </a>
-                </footer>
+<!--                <footer>-->
+<!--                    <a href="./tutorials/page/#welcome-to-kernlai" class="button button__primary&#45;&#45;outlined">-->
+<!--                        <span>See more benchmarks</span>-->
+<!--                        <svg width="25" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
+<!--                            <path d="M9.09 16.59 13.67 12 9.09 7.41 10.5 6l6 6-6 6-1.41-1.41Z"/>-->
+<!--                        </svg>-->
+<!--                    </a>-->
+<!--                </footer>-->
             </div>
         </div>
     </section>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,8 +160,8 @@ nav:
   - How to:
       - Get Started: how-to-guides/get-started.md
       - How to support a new model: how-to-guides/support-new-model.md
-  - Tutorials:
-      - Page 1: tutorials/page.md
+#  - Tutorials:
+#      - Page 1: tutorials/page.md
   - Code Reference:
       - Model Optimization: reference/model_optimization.md
       - Graph Pattern Matching: reference/extended_matcher.md
@@ -170,5 +170,5 @@ nav:
       - Code of conduct: contribution-guide/code-of-conduct.md
       - Contributing guidelines: contribution-guide/how-to-contribute.md
       - Kernel writing conventions: contribution-guide/kernel-writing-conventions.md
-  - Changelog & FAQ:
-      - Page 1: changelog/page.md
+#  - Changelog & FAQ:
+#      - Page 1: changelog/page.md


### PR DESCRIPTION
Removes/comments empty sections and navigations of the site to avoid false leads.

fix #259 