### PR TITLE
interface update for dot(), trans() for tl 2.01

### DIFF
--- a/src/kernl/debugger/tl_lang.py
+++ b/src/kernl/debugger/tl_lang.py
@@ -403,13 +403,13 @@ class TritonLangProxy:
         raise NotImplementedError()
 
     @_tensor_operation
-    def dot(self, input, other, trans_a=False, trans_b=False, allow_tf32=True):
+    def dot(self, input, other):
         assert input.dtype == other.dtype
-        if trans_a:
-            input = input.T
-        if trans_b:
-            other = other.T
         return torch.matmul(input=input, other=other)
+    
+    @_tensor_operation
+    def trans(self, input):
+        return input.T
 
     @_tensor_operation
     def atomic_cas(self, pointer, cmp, val):


### PR DESCRIPTION
1. added tl.trans()
2. removed trans_a, trans_b and allow_tf32 for tl.dot(), since removed by triton 2.01