### PR TITLE
add `tl.math.tanh` instead of `tl.libdevice.tanh`

### DIFF
--- a/src/kernl/implementations/activation_func.py
+++ b/src/kernl/implementations/activation_func.py
@@ -28,7 +28,7 @@ sqrt2 = math.sqrt(2.0)
 @triton.jit
 def tanh(x):
     """Tanh activation function"""
-    return tl.libdevice.tanh(x)
+    return tl.math.tanh(x)
 
 
 @triton.jit
@@ -46,4 +46,4 @@ def fast_gelu(x):
 @triton.jit
 def gelu(x):
     """Gaussian Error Linear Unit (GELU)"""
-    return x * 0.5 * (1.0 + tl.libdevice.erf(x / sqrt2))
+    return x * 0.5 * (1.0 + tl.math.erf(x / sqrt2))


### PR DESCRIPTION
Seems like tanh moved to a 

see triton/language/math.py-L1238
```python
@core.extern
def tanh(arg0, _builder=None):
    return core.extern_elementwise(
        "libdevice", libdevice_path(), [arg0], {
            (core.dtype("fp32"), ): ("__nv_tanhf", core.dtype("fp32")),
            (core.dtype("fp64"), ): ("__nv_tanh", core.dtype("fp64")),
        }, is_pure=True, _builder=_builder)
```